### PR TITLE
add /shop [item] shortcut for /shop search [item]

### DIFF
--- a/src/main/java/com/winthier/shop/ShopCommand.java
+++ b/src/main/java/com/winthier/shop/ShopCommand.java
@@ -68,6 +68,11 @@ public final class ShopCommand extends AbstractCommand<ShopPlugin> {
 
     protected void onEnable() {
         final NetworkServer targetServer = NetworkServer.current().getManager();
+        rootNode.arguments("[item]")
+            .denyTabCompletion()
+            .description("Search for shop chests")
+            .remoteServer(targetServer)
+            .senderCaller(this::search);
         rootNode.addChild("search").arguments("[item]")
             .denyTabCompletion()
             .description("Search for shop chests")


### PR DESCRIPTION
Adds a shortcut so that `/shop [item]` can be used instead of `/shop search [item]`, equivalent to the respective [search function in the mass storage plugin](https://github.com/StarTux/MassStorage/blob/cfcd2b2dd58dbf7f520969c4d3d08286f1e859b5/src/main/java/com/cavetale/ms/MassStorageCommand.java#L30).